### PR TITLE
Added avl_node class to core module

### DIFF
--- a/ares-engine/modules/core/include/core/data/avl_node.h
+++ b/ares-engine/modules/core/include/core/data/avl_node.h
@@ -1,0 +1,36 @@
+#ifndef ARES_CORE_AVL_NODE_H
+#define ARES_CORE_AVL_NODE_H
+#include <EASTL/type_traits.h>
+
+namespace ares::core {
+
+	template <typename key, typename value = void>
+	struct avl_node
+	{
+	private:
+		struct empty_value {};
+
+	public:
+		using value_type = eastl::conditional_t<
+			eastl::is_void_v<value>,
+			key,
+			eastl::pair<const key, value>
+		>;
+
+		avl_node() = default;
+		~avl_node() = default;
+
+		avl_node(const value_type& kv) : data(kv) {}
+		avl_node(value_type&& kv) : data(eastl::move(kv)) {}
+
+		value_type data;
+
+		avl_node* left = nullptr;
+		avl_node* right = nullptr;
+		avl_node* parent = nullptr;
+		int32_t height = 0;
+	};
+
+}
+
+#endif // ARES_CORE_AVL_NODE_H


### PR DESCRIPTION
The `avl_node` class has been added to the core module. This was needed to start work on the `avl_tree_iterator` class and the actual `avl_tree` class.
[ARES-12]

[ARES-12]: https://jackpphillips.atlassian.net/browse/ARES-12?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ