### PR TITLE
Added avl_tree_iterator class to the core module

### DIFF
--- a/ares-engine/modules/core/include/core/data/avl_tree_iterator.h
+++ b/ares-engine/modules/core/include/core/data/avl_tree_iterator.h
@@ -1,0 +1,204 @@
+#ifndef ARES_CORE_AVL_TREE_ITERATOR_H
+#define ARES_CORE_AVL_TREE_ITERATOR_H
+#include <EASTL/iterator.h>
+#include <core/data/avl_node.h>
+
+namespace ares::core {
+
+	template <typename avl_node, typename value>
+	class avl_tree_iterator
+	{
+	private:
+		template <typename T>
+		struct avl_tree_iterator_traits_helper
+		{
+			using pointer = T*;
+			using reference = T&;
+		};
+
+		template <>
+		struct avl_tree_iterator_traits_helper<void>
+		{
+			using pointer = void;
+			using reference = void;
+		};
+
+	public:
+		using value_type = value;
+		using pointer = typename avl_tree_iterator_traits_helper<value>::pointer;
+		using reference = typename avl_tree_iterator_traits_helper<value>::reference;
+		using iterator_category = eastl::bidirectional_iterator_tag;
+		using difference_type = std::ptrdiff_t;
+
+		avl_tree_iterator();
+		explicit avl_tree_iterator(avl_node* node);
+
+		avl_tree_iterator(const avl_tree_iterator& other);
+		avl_tree_iterator& operator=(const avl_tree_iterator& other);
+
+		template <typename other_node, typename other_value, typename = eastl::enable_if_t<
+			eastl::is_convertible_v<other_node*, avl_node*>&&
+			eastl::is_convertible_v<other_value*, value*>
+		>>
+		avl_tree_iterator(const avl_tree_iterator<other_node, other_value>& other);
+
+		pointer operator->() const;
+		reference operator*() const;
+
+		avl_tree_iterator& operator++();
+		avl_tree_iterator operator++(int);
+
+		avl_tree_iterator& operator--();
+		avl_tree_iterator operator--(int);
+
+		bool operator==(const avl_tree_iterator& other) const;
+		bool operator!=(const avl_tree_iterator& other) const;
+
+		avl_node* get_node() const;
+
+	private:
+		avl_node* maximum(avl_node* node) const;
+		avl_node* minimum(avl_node* node) const;
+
+	private:
+		avl_node* m_node = nullptr;
+		template <typename, typename> friend class avl_tree_iterator;
+	};
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>::avl_tree_iterator()
+		: m_node(nullptr)
+	{
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>::avl_tree_iterator(avl_node* node)
+		: m_node(node)
+	{
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>::avl_tree_iterator(const avl_tree_iterator<avl_node, value>& other)
+		: m_node(other.m_node)
+	{
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>& avl_tree_iterator<avl_node, value>::operator=(const avl_tree_iterator<avl_node, value>& other)
+	{
+		if (this != &other)
+		{
+			m_node = other.m_node;
+		}
+		return *this;
+	}
+
+	template <typename avl_node, typename value>
+	template <typename other_node, typename other_value, typename>
+	inline avl_tree_iterator<avl_node, value>::avl_tree_iterator(const avl_tree_iterator<other_node, other_value>& other)
+		: m_node(other.m_node)
+	{
+	}
+
+	template <typename avl_node, typename value>
+	inline typename avl_tree_iterator<avl_node, value>::pointer avl_tree_iterator<avl_node, value>::operator->() const
+	{
+		return &m_node->data;
+	}
+
+	template <typename avl_node, typename value>
+	inline typename avl_tree_iterator<avl_node, value>::reference avl_tree_iterator<avl_node, value>::operator*() const
+	{
+		return m_node->data;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>& avl_tree_iterator<avl_node, value>::operator++()
+	{
+		if (m_node->right)
+		{
+			m_node = minimum(m_node->right);
+		}
+		else
+		{
+			avl_node* parent = m_node->parent;
+			while (parent && m_node == parent->right)
+			{
+				m_node = parent;
+				parent = parent->parent;
+			}
+			m_node = parent;
+		}
+		return *this;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value> avl_tree_iterator<avl_node, value>::operator++(int)
+	{
+		avl_tree_iterator temp = *this;
+		++(*this);
+		return temp;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value>& avl_tree_iterator<avl_node, value>::operator--()
+	{
+		if (m_node->left)
+		{
+			m_node = maximum(m_node->left);
+		}
+		else
+		{
+			avl_node* parent = m_node->parent;
+			while (parent && m_node == parent->left)
+			{
+				m_node = parent;
+				parent = parent->parent;
+			}
+			m_node = parent;
+		}
+		return *this;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_tree_iterator<avl_node, value> avl_tree_iterator<avl_node, value>::operator--(int)
+	{
+		avl_tree_iterator temp = *this;
+		--(*this);
+		return temp;
+	}
+
+	template <typename avl_node, typename value>
+	inline bool avl_tree_iterator<avl_node, value>::operator==(const avl_tree_iterator& other) const
+	{
+		return m_node == other.m_node;
+	}
+
+	template <typename avl_node, typename value>
+	inline bool avl_tree_iterator<avl_node, value>::operator!=(const avl_tree_iterator& other) const
+	{
+		return m_node != other.m_node;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_node* avl_tree_iterator<avl_node, value>::get_node() const
+	{
+		return m_node;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_node* avl_tree_iterator<avl_node, value>::maximum(avl_node* node) const
+	{
+		while (node->right) node = node->right;
+		return node;
+	}
+
+	template <typename avl_node, typename value>
+	inline avl_node* avl_tree_iterator<avl_node, value>::minimum(avl_node* node) const
+	{
+		while (node->left) node = node->left;
+		return node;
+	}
+}
+
+#endif // ARES_CORE_AVL_TREE_ITERATOR_H


### PR DESCRIPTION
The `avl_tree_iterator` class has been added to the core module. This was needed to start work on the actual `avl_tree` class.
[ARES-15, ARES-11]